### PR TITLE
Zero Amount

### DIFF
--- a/packages/react-native-payments/lib/js/helpers/index.js
+++ b/packages/react-native-payments/lib/js/helpers/index.js
@@ -110,24 +110,22 @@ export function getPlatformMethodData(
   return platformMethod.data;
 }
 
-function validateIosHasAmount() {
-  if (Platform.OS === 'ios' && parseInt(Platform.Version, 10) < 12) {
-    throw new errorType(`Missing required member(s): amount. Only for versions of iOS later to version 12.0`);
-  }
+//Verifies if Zero Amount is supported by the device
+function supportsZeroAmount() {
+  return Platform.OS === 'ios' && parseInt(Platform.Version) >= 12;
 }
 
 // Validators
 export function validateTotal(total, errorType = Error): void {
   // Should Vailidator take an errorType to prepopulate "Failed to construct 'PaymentRequest'"
-
   if (total === undefined) {
     throw new errorType(`required member total is undefined.`);
   }
 
   const hasTotal = total && total.amount && total.amount.value;
   // Check that there is a total
-  if (hasTotal < 0 && validateIosHasAmount()) {
-    throw new errorType(`Missing required member(s): amount.`);
+  if (!hasTotal && !supportsZeroAmount()) {
+    throw new errorType(`Amount cannot be zero or null. Only for iOS versions after 12.0`);
   }
 
   const totalAmountValue = total.amount.value;
@@ -188,8 +186,8 @@ export function validateDisplayItems(displayItems, errorType = Error): void {
     displayItems.forEach((item: PaymentItem) => {
       const amountValue = item && item.amount && item.amount.value;
 
-      if ( amountValue < 0 && validateIosHasAmount()) {
-        throw new errorType(`required member value is undefined.`);
+      if (!amountValue && !supportsZeroAmount()) {
+        throw new errorType(`Amount cannot be zero or null. Only for iOS versions after 12.0`);
       }
 
       if (!isValidDecimalMonetaryValue(amountValue)) {

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-payments",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",
     "run:ios": "cd examples/native && yarn run:ios",


### PR DESCRIPTION
According to [documentation](https://developer.apple.com/documentation/passkit/pkpaymentrequest/1619231-paymentsummaryitems):
> In versions of iOS prior to version 12.0 and watchOS prior to version 5.0, the amount of the grand total must be greater than zero.

The change validates if it's an ios device and if the version is greater or equal to 12, to authorise amount = 0,